### PR TITLE
Invert 'clean room' behaviour in unit tests

### DIFF
--- a/spec/classes/profile/common/packages_spec.rb
+++ b/spec/classes/profile/common/packages_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
 describe 'Profile::Common::Packages' do
-  include_context 'clean room'
-
   packages = {
     rsync:  'installed',
     screen: 'purged',

--- a/spec/classes/profile/example_spec.rb
+++ b/spec/classes/profile/example_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
 describe 'Profile::Example' do
-  include_context 'clean room'
-
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }

--- a/spec/functions/profile/banner_spec.rb
+++ b/spec/functions/profile/banner_spec.rb
@@ -1,7 +1,5 @@
 require 'spec_helper'
 
 describe 'Profile::Banner' do
-  include_examples 'clean room'
-
   it { is_expected.to run.and_return(%r{managed by puppet}i) }
 end

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -17,15 +17,30 @@ module_path = [
   # File.expand_path(File.join(File.dirname(__FILE__), 'fixtures', 'modules')),
 ] + env_module_paths
 
+# Shared context to enable hiera if required
+RSpec.shared_context 'with_hiera' do
+  let(:hiera_config) { File.join(project_dir, 'hiera.yaml') }
+end
+
+# "clean room" shared context
+RSpec.shared_context 'clean_room' do
+  let(:node) { 'this.is.only.used.for.unit.tests' }
+  let(:hiera_config) { '/dev/null' }
+end
+
 RSpec.configure do |c|
   c.module_path = module_path.join(':')
   c.setup_fixtures = false
   c.manifest_dir = File.join(project_dir, 'manifests')
   c.manifest = File.join(c.manifest_dir, 'site.pp')
-  c.hiera_config = File.join(project_dir, 'hiera.yaml')
-end
+  c.hiera_config = '/dev/null' # No hiera for unit tests by default
 
-RSpec.shared_context 'clean room' do
-  let(:node) { 'this.is.only.used.for.unit.tests' }
-  let(:hiera_config) { '/dev/null' }
+  # To remove on RSpec >= 4
+  # https://relishapp.com/rspec/rspec-core/v/3-12/docs/example-groups/shared-context
+  c.shared_context_metadata_behavior = :apply_to_host_groups
+
+  # Run non-host tests in a clean room (fake node, no hiera)
+  c.include_context 'clean_room', file_path: proc { |x| !File.dirname(x).end_with? 'hosts' }
+  # Run host tests with hiera enabled
+  c.include_context 'with_hiera', file_path: proc { |x| File.dirname(x).end_with? 'hosts' }
 end

--- a/spec/type_aliases/profile/ensure_spec.rb
+++ b/spec/type_aliases/profile/ensure_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
 describe 'Profile::Ensure' do
-  include_examples 'clean room'
-
   it { is_expected.to allow_values('absent', 'present') }
   it { is_expected.not_to allow_values('anything', 'else') }
 end


### PR DESCRIPTION
No need to include 'clean room' shared context to unit tests anymore. It's default behaviour now. Only host tests run with hiera enabled.

Closes #2 