### PR TITLE
Install build essential and Bolt

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,5 +2,21 @@ FROM puppet/pdk:latest
 
 # [Optional] Uncomment this section to install additional packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
+#     && apt-get --yes install --no-install-recommends <your-package-list-here>
 
+#
+# Remove when [Install build essentials and Puppet Bolt](https://github.com/puppetlabs/pdk-docker/pull/72) is merged and image published:
+RUN apt-get update \
+    #
+    # To build Gem native extension:
+    && apt-get install --yes build-essential \
+    #
+    # Install Puppet Bolt.
+    && pdk_ruby_bindir="$(dirname "$(ls -dr /opt/puppetlabs/pdk/private/ruby/*/bin/gem | head -1)")" \
+    && "${pdk_ruby_bindir}/gem" install --no-document bolt --version '3.30.0' \
+    && ln -s "${pdk_ruby_bindir}/bolt" /usr/local/bin/bolt
+
+# Avoid this warning:
+#   Project directory '/workspaces/puppetbolt-control_repo' is world-writable which poses a security risk.
+#   Set BOLT_PROJECT='/workspaces/puppetbolt-control_repo' to force the use of this project directory.
+ENV BOLT_PROJECT='/workspaces/puppetbolt-control_repo'

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
-*.rb eol=lf
-*.erb eol=lf
-*.pp eol=lf
-*.sh eol=lf
-*.epp eol=lf
+# From [Resolving Git line ending issues in containers (resulting in many modified files)](https://code.visualstudio.com/docs/devcontainers/tips-and-tricks#_resolving-git-line-ending-issues-in-containers-resulting-in-many-modified-files)
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf


### PR DESCRIPTION
- Install Build Essential to build Gem native extension during `pdk test unit`.
- Install Bolt to develop Bolt project in Visual Studio Code Dev Container.
- Avoid EOL issues in Visual Studio Code Dev Container.